### PR TITLE
chore(webapp): use location host instead of static localhost

### DIFF
--- a/webapp/lib/app/controller/appCtrl.js
+++ b/webapp/lib/app/controller/appCtrl.js
@@ -30,7 +30,7 @@ var Controller = ['$scope', '$location', function($scope, $location) {
     }
   };
 
-  var serverUrl = "ws://localhost:9090/debug-session";
+  var serverUrl = "ws://" + $location.host() + ":9090/debug-session";
 
   // the global event bus
   var eventBus = new EventBus();


### PR DESCRIPTION
- allows the user to deploy the workbench on a remote host